### PR TITLE
Correct and update hyperlinks across documentation

### DIFF
--- a/datasets/dataset_2.md
+++ b/datasets/dataset_2.md
@@ -1,5 +1,5 @@
 ## NCI-COG Pediatric MATCH Precision Medicine Clinical Trial
-PedMATCH’s underlying raw sequencing data can be searched through the [CCDI Hub Explore](https://ccdi.cancer.gov/explore?dbgap_accession=phs002790). Controlled-access data is available via dbGaP authorization under accession number [phs002883](https://ccdi.cancer.gov/explore?dbgap_accession=phs002883&tab=1).
+PedMATCH’s underlying raw sequencing data can be searched through the [CCDI Hub Explore](https://ccdi.cancer.gov/explore?dbgap_accession=phs002883). Controlled-access data is available via dbGaP authorization under accession number [phs002883](https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002883.v1.p1).
 
 ### Clinical Data
 Clinical data, including diagnosis, diagnosis age, survival and treatments, were sourced from Children’s Oncology Group (COG)-provided clinical data files. 


### PR DESCRIPTION
This pull request updates the dataset documentation to correct and clarify the links for accessing PedMATCH sequencing data. The main change is updating the URLs to ensure users are directed to the correct resources.

Documentation update:

* Updated the public and controlled-access links for PedMATCH raw sequencing data in `datasets/dataset_2.md` to point to the correct CCDI Hub Explore page and the official dbGaP study page, respectively.