### PR TITLE
Release v1.3.1 with modules.json updates and formatting fixes

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -59,6 +59,11 @@
         "id": "ccdi-cbio-content-releases-2026-1",
         "path": "releases/2026/release_v1.3.md"
       }
+      { 
+        "title": "Version v1.3.1", 
+        "id": "ccdi-cbio-content-releases-2026-2", 
+        "path": "releases/2026/release_v1.3.1.md" 
+      }
     ]
   },
   "images": [

--- a/modules.json
+++ b/modules.json
@@ -58,7 +58,7 @@
         "title": "Version v1.3.0",
         "id": "ccdi-cbio-content-releases-2026-1",
         "path": "releases/2026/release_v1.3.md"
-      }
+      },
       { 
         "title": "Version v1.3.1", 
         "id": "ccdi-cbio-content-releases-2026-2", 

--- a/releases/2026/release_v1.3.1.md
+++ b/releases/2026/release_v1.3.1.md
@@ -1,0 +1,15 @@
+<div
+    class="gap-10 w-full max-md:max-w-full text-sky-800"
+    style="
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        margin-bottom: 0.375rem;
+    "
+>
+    <h2 class="self-stretch my-auto text-base font-bold leading-none">Version v1.3.1</h2>
+    <h3 class="self-stretch my-auto text-sm font-normal leading-none">August 2026</h3>
+</div>
+
+The 1.3.1 patch release includes updates to address security vulnerabilities.


### PR DESCRIPTION
This pull request adds documentation for the new v1.3.1 patch release, including its metadata and release notes. The main changes are:

**Release Documentation Updates:**

* Added a new entry for v1.3.1 in `modules.json` to include the release in the list of available versions.
* Created a new release notes file `releases/2026/release_v1.3.1.md` that summarizes the 1.3.1 patch release, highlighting updates to address security vulnerabilities.